### PR TITLE
add the word 'Score:' before the score

### DIFF
--- a/public/assets/js/front-end-burger.js
+++ b/public/assets/js/front-end-burger.js
@@ -95,7 +95,7 @@ $(document).ready(function () {
     commentsLink.addClass("comments");
     commentsLink.attr('id', `${restaurant.id}`)
     var score = $("<p>");
-    score.text(restaurant.Score + " ");
+    score.text("Score: " + restaurant.Score + " ");
     score.addClass(`score`);
     score.attr('id', `score-${restaurant.id}`)
     score.data("score", restaurant.Score);


### PR DESCRIPTION
I just changed the front end java script so it displays the score as 'Score: 1' instead of just the number. It doesn't appear to have affected the functionality.